### PR TITLE
Added text shadow to header in new users page

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -93,17 +93,26 @@ i{
 }
 
 .newuser h3{
-    font-size: 3rem;
+    font-size: 3.5rem;
     margin-bottom: 20px;
+    text-shadow:0rem 0.25rem 0.15rem #4e0888;
 }
 
 .newuser h4 a{
     text-decoration: none;
+    color: white;
+    text-decoration: underline white;
+    text-shadow:0rem 0.15rem 0.1rem #4e0888;
+}
+
+.newuser h4 a:hover{
+    text-shadow: 0rem 0.15rem 0.1rem #8907f3;
 }
 
 .newuser h4{
     padding: 5px 0;
     font-weight: 300;
+    text-shadow:0rem 0.15rem 0.1rem #4e0888;
 }
 
 .imagebox{

--- a/public/styles.css
+++ b/public/styles.css
@@ -101,12 +101,18 @@ i{
 .newuser h4 a{
     text-decoration: none;
     color: white;
-    text-decoration: underline white;
-    text-shadow:0rem 0.15rem 0.1rem #4e0888;
+    /* text-decoration: underline white; */
+    /* text-shadow:0rem 0.15rem 0.1rem #4e0888; */
+    text-shadow: none;
+    color: white;
+    font-weight: bold;
+    font-style: italic;
 }
 
 .newuser h4 a:hover{
-    text-shadow: 0rem 0.15rem 0.1rem #8907f3;
+    /* text-decoration: underline; */
+    color: white;
+    text-shadow: 0rem 0.15rem 0.1rem #4e0888;
 }
 
 .newuser h4{

--- a/public/styles.css
+++ b/public/styles.css
@@ -101,8 +101,6 @@ i{
 .newuser h4 a{
     text-decoration: none;
     color: white;
-    /* text-decoration: underline white; */
-    /* text-shadow:0rem 0.15rem 0.1rem #4e0888; */
     text-shadow: none;
     color: white;
     font-weight: bold;
@@ -110,7 +108,6 @@ i{
 }
 
 .newuser h4 a:hover{
-    /* text-decoration: underline; */
     color: white;
     text-shadow: 0rem 0.15rem 0.1rem #4e0888;
 }


### PR DESCRIPTION
Resolves #18 
Add text shadow to the header text and also changed the color of the 'Add Work' link. It is underlined to denote that it's a link and the text-shadow color lightens when you hover the cursor over it.

![image](https://user-images.githubusercontent.com/54014518/96020420-a0620500-0e6b-11eb-90d2-c1a1bc0afe33.png)

On hover: 
![Screenshot from 2020-10-14 22-21-50](https://user-images.githubusercontent.com/54014518/96021714-74478380-0e6d-11eb-866a-5bd1bcfbc821.png)
